### PR TITLE
fix: Safari 26 Liquid Glass tinting + wave layout + button spacing

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -55,7 +55,7 @@ export default function HeroSection() {
             conferences and projects that I take part in.
           </p>
           <div
-            className="grid gap-0 justify-center max-xs:justify-around"
+            className="grid gap-[30px] justify-start max-lg:justify-center max-xs:justify-around"
             style={{
               gridTemplateColumns: `repeat(${socialLinks.length}, auto)`,
             }}


### PR DESCRIPTION
## Summary\n\nFixes the layout regression introduced in PR #62 while keeping Safari 26 Liquid Glass toolbar tinting working.\n\n## Changes\n\n### Wave layout fix (`isolation: isolate`)\nAdded `isolate` class to all 7 wave container components:\n- `WaveHero`, `WaveBody`, `WaveShort`, `WaveFooter`, `WaveNewsHome`, `WavePostHome`, `WaveResumeeHome`\n\n**Root cause**: PR #62 added `html { background-color }` for Safari tinting. Per CSS spec, when `html` has an explicit background, `body`'s background stops propagating to the viewport canvas. In the root stacking context, `body` (normal flow) painted on top of the negative z-index wave elements, hiding them. Adding `isolation: isolate` creates a stacking context on each wave container so their children paint correctly.\n\n### Safari 26 tinting (kept from PR #62)\n- `html { background-color: var(--page-top-color) }` in globals.css\n- `useEffect` in SEO.tsx setting CSS custom properties per page\n- `<meta name=\"theme-color\">` tags with `prefers-color-scheme` media queries\n\n### Button spacing fix\n- Changed social buttons grid container from `gap-0` to `gap-[30px]` with `justify-start` on desktop and `max-lg:justify-center` on mobile\n\n## Testing\n- Build passes\n- 14 test suites, 71 tests pass