### PR TITLE
Revert &quot;Fix Safari Liquid Glass toolbar tinting&quot; (PR #62)

### DIFF
--- a/src/components/layout/SEO.tsx
+++ b/src/components/layout/SEO.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Helmet } from "react-helmet-async";
 
 interface SEOProps {
@@ -32,11 +31,6 @@ export default function SEO({
   const metaDescription = description || SITE_METADATA.description;
   const metaImage = image || SITE_METADATA.image;
   const metaUrl = url || SITE_METADATA.url;
-
-  useEffect(() => {
-    document.documentElement.style.setProperty("--page-top-color", themeColor);
-    document.documentElement.style.setProperty("--page-top-color-dark", themeColorDark);
-  }, [themeColor, themeColorDark]);
 
   return (
     <Helmet

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -217,23 +217,10 @@
 }
 
 /* ===========================
-   Safari Toolbar Tinting
-   (html bg extends into safe-area for Liquid Glass toolbar)
-   =========================== */
-
-html {
-  background-color: var(--page-top-color, var(--color-primary));
-}
-
-/* ===========================
    Dark Mode
    =========================== */
 
 @media (prefers-color-scheme: dark) {
-  html {
-    background-color: var(--page-top-color-dark, #9D7E50);
-  }
-
   body {
     background: var(--color-background-dark);
   }


### PR DESCRIPTION
Reverts commit 70d92b1 from PR #62 which broke the wave/gradient rendering.\n\nThe `html { background-color }` and `useEffect` in SEO.tsx caused body's background to paint over negative z-index wave elements, hiding all wave backgrounds and gradients.\n\nThis revert removes:\n- `html { background-color: var(--page-top-color) }` from globals.css\n- `useEffect` setting CSS custom properties in SEO.tsx\n\nSafari 26 Liquid Glass tinting will be re-implemented properly in a follow-up PR.